### PR TITLE
feat(#22): TypeString trait to get string of type name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ version = "1.0.0"
 dependencies = [
  "async-nats",
  "chrono",
+ "common_derive",
  "futures-util",
  "prost",
  "prost-build",
@@ -366,6 +367,10 @@ dependencies = [
 [[package]]
 name = "common_derive"
 version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1597,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2317,9 +2322,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "common_derive"
+version = "0.1.0"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["api_gateway", "common", "common_derive", "data_persistor", "shorts_service", "test_tool"]
+members = ["api_gateway", "common", "common_derive", "common_derive", "data_persistor", "shorts_service", "test_tool"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["api_gateway", "common", "data_persistor", "shorts_service", "test_tool"]
+members = ["api_gateway", "common", "common_derive", "data_persistor", "shorts_service", "test_tool"]

--- a/api_gateway/src/handlers/short_handler.rs
+++ b/api_gateway/src/handlers/short_handler.rs
@@ -4,6 +4,7 @@ use axum::body::Body;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use common::TypeString;
 use common::models::messaging::{CreateShortCommand, ShortCreatedEvent};
 use common::models::rest::CreateShortRequest;
 use prost::Message;
@@ -32,7 +33,7 @@ pub async fn handle_short_post(
     let short_command: CreateShortCommand = short_request.into();
     let mut nats_headers = async_nats::HeaderMap::new();
     nats_headers.insert("correlation_id", correlation_id.clone());
-    nats_headers.insert("message_type", "CreateShortRequest");
+    nats_headers.insert("message_type", short_command.type_as_string());
     nats_headers.insert("response_subject", "api_gateway::response");
     info!(
         "Sending request with X-Correlation-Id '{}'",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 async-nats = "0.48.0"
 chrono = "0.4.44"
+common_derive = { path = "../common_derive" }
 futures-util = "0.3.31"
 prost = "0.14.3"
 rmp-serde = "1.3.1"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -4,6 +4,8 @@ pub mod models;
 pub mod nats_utils;
 pub mod pg_utils;
 pub mod proto;
+pub mod traits;
+pub use traits::TypeString;
 
 pub fn setup_logging() {
     if cfg!(debug_assertions) {

--- a/common/src/models/messaging/commands/create_short_command.rs
+++ b/common/src/models/messaging/commands/create_short_command.rs
@@ -1,8 +1,9 @@
+use crate::TypeString;
 use crate::models::rest::CreateShortRequest;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, TypeString)]
 pub struct CreateShortCommand {
     pub request_time: i64,
     pub long_url: String,

--- a/common/src/models/messaging/commands/persist_short_command.rs
+++ b/common/src/models/messaging/commands/persist_short_command.rs
@@ -1,7 +1,8 @@
+use crate::TypeString;
 use crate::models::short_url::ShortUrl;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, TypeString)]
 pub struct PersistShortCommand {
     pub short: ShortUrl,
     pub created: i64,

--- a/common/src/models/messaging/commands/retrieve_short_command.rs
+++ b/common/src/models/messaging/commands/retrieve_short_command.rs
@@ -1,6 +1,7 @@
+use crate::TypeString;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, TypeString)]
 pub struct RetrieveShortCommand {
     pub request_time: i64,
     pub short_url: String,

--- a/common/src/models/messaging/events/short_created_event.rs
+++ b/common/src/models/messaging/events/short_created_event.rs
@@ -1,7 +1,8 @@
+use crate::TypeString;
 use crate::models::short_url::ShortUrl;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, TypeString)]
 pub struct ShortCreatedEvent {
     pub short: ShortUrl,
     pub instance_id: String,

--- a/common/src/models/messaging/events/short_retrieved_event.rs
+++ b/common/src/models/messaging/events/short_retrieved_event.rs
@@ -1,5 +1,7 @@
+use crate::TypeString;
 use crate::models::short_url::ShortUrl;
 
+#[derive(TypeString)]
 pub struct ShortRetrievedEvent {
     pub short: ShortUrl,
     pub instance_id: String,

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -1,0 +1,5 @@
+pub use common_derive::TypeString;
+
+pub trait TypeString {
+    fn type_as_string(&self) -> String;
+}

--- a/common_derive/Cargo.toml
+++ b/common_derive/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "common_derive"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/common_derive/Cargo.toml
+++ b/common_derive/Cargo.toml
@@ -3,4 +3,9 @@ name = "common_derive"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+proc-macro = true
+
 [dependencies]
+quote = "1.0.45"
+syn = "2.0.117"

--- a/common_derive/src/lib.rs
+++ b/common_derive/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/common_derive/src/lib.rs
+++ b/common_derive/src/lib.rs
@@ -1,14 +1,18 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, parse_macro_input};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[proc_macro_derive(TypeString)]
+pub fn derive_type_to_string(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+    let expanded = quote! {
+        impl TypeString for #name {
+            fn type_as_string(&self) -> String {
+                ::std::any::type_name_of_val(&self).split("::").last().unwrap().to_string()
+            }
+        }
+    };
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+    TokenStream::from(expanded)
 }

--- a/data_persistor/src/main.rs
+++ b/data_persistor/src/main.rs
@@ -35,14 +35,14 @@ pub async fn process_message(
 ) -> Result<(), sqlx::Error> {
     debug!("Message payload: {:?}", &message.message);
 
-    let message_type =
-        get_header_value(&message.message.headers, "message_type").unwrap_or_else(|| "none");
+    let message_type = get_header_value(&message.message.headers, "message_type").unwrap_or("none");
     let correlation_id = get_header_value(&message.message.headers, "correlation_id")
-        .unwrap_or_else(|| "hehehee")
+        .unwrap_or("hehehee")
         .to_string();
 
     info!("Received {} message", message_type);
 
+    // TODO: Fix this match string
     match message_type {
         "PersistShortCommand" => {
             persist_short_command(&message.message.payload, correlation_id, db_pool, jetstream)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
     "common": {
       "path": "common"
     },
+    "common_derive": {
+      "path": "common_derive"
+    },
     "data_persistor": {
       "path": "data_persistor"
     },
@@ -19,4 +22,3 @@
     }
   }
 }
-

--- a/test_tool/src/main.rs
+++ b/test_tool/src/main.rs
@@ -7,11 +7,11 @@ use common::models::messaging::{
 };
 use common::models::short_url::ShortUrl;
 use common::nats_utils::create_consumer;
-use common::setup_logging;
+use common::{TypeString, setup_logging};
 use futures_util::TryStreamExt;
 use prost::Message;
 use std::time::SystemTime;
-use tracing::info;
+use tracing::{debug, info};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -46,7 +46,7 @@ async fn send_persistence_request(jetstream: Context) -> Result<(), async_nats::
             .cast_signed(),
     );
     let mut headers = HeaderMap::new();
-    headers.insert("message_type", "PersistShortCommand");
+    headers.insert("message_type", data.type_as_string());
     headers.insert("correlation_id", "test-tool");
 
     info!("Publishing message: {:?}", data);
@@ -73,8 +73,9 @@ async fn send_retrieve_short_command(jetstream: Context) -> Result<(), async_nat
         String::from("1234"),
     );
 
-    headers.insert("message_type", "RetrieveShortCommand");
+    headers.insert("message_type", data.type_as_string());
     headers.insert("correlation_id", "test-tool");
+    debug!("Headers set: {:?}", headers);
 
     info!("Publishing message: {:?}", data);
     jetstream
@@ -99,7 +100,7 @@ async fn send_create_short_request(jetstream: Context) -> Result<(), async_nats:
         3600,
     );
     let mut headers = HeaderMap::new();
-    headers.insert("message_type", "CreateShortRequest");
+    headers.insert("message_type", create_short_request.type_as_string());
 
     info!("Publishing message: {:?}", create_short_request);
     jetstream
@@ -118,7 +119,7 @@ async fn send_short_created_response(jetstream: Context) -> Result<(), async_nat
     let short = ShortUrl::new("/retcd".into(), "http://hltv.org/".into(), 86400);
     let created_short = ShortCreatedEvent::new(short, "test_tool".into());
     let mut headers = HeaderMap::new();
-    headers.insert("message_type", "CreatedShortResponse");
+    headers.insert("message_type", created_short.type_as_string());
     headers.insert("correlation_id", "test-tool");
 
     info!("Publishing message: {:?}", created_short);


### PR DESCRIPTION
Created simple TypeString trait with function ```type_as_string(&self) -> String```

All messaging structs need to derive this trait as
```rust
#[derive(TypeString)]
struct SomeStruct {}
```